### PR TITLE
Add podmonitor for collecting qdrant /metrics

### DIFF
--- a/kubernetes/podmonitor.yaml
+++ b/kubernetes/podmonitor.yaml
@@ -1,0 +1,20 @@
+# Using a podmonitor since the headless service causes duplicatation
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: qdrant-haloperidol
+  namespace: haloperidol
+  labels:
+    app.kubernetes.io/name: haloperidol
+spec:
+  selector:
+    matchLabels:
+      app: qdrant
+      cluster-id: haloperidol
+      customer-id: haloperidol
+  namespaceSelector:
+    matchNames:
+    - haloperidol
+  podMetricsEndpoints:
+  - port: rest
+    interval: 30s


### PR DESCRIPTION
This PR creates a [PodMonitor](https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors) that tells prometheus to start scraping metrics from the qdrant cluster in the haloperidol namespace.