### PR TITLE
Set correct hostname for qdrantcluster

### DIFF
--- a/kubernetes/qdrantcluster.yaml
+++ b/kubernetes/qdrantcluster.yaml
@@ -19,7 +19,7 @@ spec:
     storage: "8Gi"
   ingress:
     type: host
-    host: qdrant-haloperidol
+    host: haloperidol.eu-central.aws.staging-cloud.qdrant.io
   tolerations:
     - key: dedicated
       # When running locally, change this to "free-tier"


### PR DESCRIPTION
Merging this should unblock you for now, but I'll still need to commit the documentation update for this change which requires a private repo.