### PR TITLE
feat: Use common timestamp and handle non JSON response

### DIFF
--- a/tools/local/collect-stats.sh
+++ b/tools/local/collect-stats.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 export QDRANT_CLUSTER_URL=${QDRANT_CLUSTER_URL:-""}
 export QDRANT_API_KEY=${QDRANT_API_KEY:-""}
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # https is important here
 QDRANT_URIS=( ${QDRANT_HOSTS[@]/#/https://} )
@@ -56,7 +57,7 @@ for uri in "${QDRANT_URIS[@]}"; do
         PSQL_VALUES+=" ,"
     fi
 
-    PSQL_VALUES+=" ('$uri', '$version', '$commit_id', $num_vectors, $num_snapshots, '$(date -u +"%Y-%m-%dT%H:%M:%SZ")')"
+    PSQL_VALUES+=" ('$uri', '$version', '$commit_id', $num_vectors, $num_snapshots, '$NOW')"
 
     sleep 1
 done

--- a/tools/local/collect-stats.sh
+++ b/tools/local/collect-stats.sh
@@ -14,7 +14,7 @@ for uri in "${QDRANT_URIS[@]}"; do
     echo "$uri"
 
     root_api_response=$(curl --url "$uri/" --header "api-key: $QDRANT_API_KEY")
-    if ! (echo "$root_api_response" | jq); then
+    if ! (echo "$root_api_response" | jq -e '.'); then
         continue
     fi
 

--- a/tools/local/collect-stats.sh
+++ b/tools/local/collect-stats.sh
@@ -14,6 +14,9 @@ for uri in "${QDRANT_URIS[@]}"; do
     echo "$uri"
 
     root_api_response=$(curl --url "$uri/" --header "api-key: $QDRANT_API_KEY")
+    if ! (echo "$root_api_response" | jq); then
+        continue
+    fi
 
     version=$(echo "$root_api_response" | jq -r '.version')
     # if crashes or version null, then skip


### PR DESCRIPTION
- jq makes the script fail in `collect-stats` cron fails when a node is killed.
- Use common timestamp for the whole cron to make Grafana queries simpler.