### PR TITLE
fix: Set bfb upload timeout to 10s

### DIFF
--- a/tools/local/run-bfb-upload.sh
+++ b/tools/local/run-bfb-upload.sh
@@ -26,6 +26,7 @@ BFB_PARAMETERS=" \
     --on-disk-vectors true \
     --max-id 200000 \
     --delay 100 \
+    --timeout 10
 "
 
 docker stop -t 10 ${BFB_CONTAINER_NAME} || true


### PR DESCRIPTION
BFB status checks fail very often because some requests take more than 1s.

This makes [bfb status check workflow](https://github.com/qdrant/haloperidol/actions/workflows/check-bfb-status.yaml) fail very often (as `bfb-upload` crashes and is restarted once a day)