### PR TITLE
fix: Collection should use 6 shards with replication factor = 1

### DIFF
--- a/tools/local/run-bfb-upload.sh
+++ b/tools/local/run-bfb-upload.sh
@@ -12,7 +12,8 @@ QDRANT_URIS=( ${QDRANT_URIS[@]/%/:6334} )
 
 BFB_PARAMETERS=" \
     ${QDRANT_URIS[@]/#/--uri } \
-    --replication-factor 2 \
+    --replication-factor 1 \
+    --shards 6
     --keywords 10 \
     --dim 768 \
     -n 1000000000 \


### PR DESCRIPTION
Our setup has 3 nodes at min so each node will get 2 shards. 

When the cluster scales to 4 nodes, one of the 2 shards from 1st node will be transferred to node 4. 

When it downscales again, the same shard shall return back to node 1. 