### PR TITLE
feat: pass ENV_CONTEXT before script

### DIFF
--- a/tools/run_remote.sh
+++ b/tools/run_remote.sh
@@ -42,5 +42,8 @@ else
     # Could directly cat inside screen instead of using scp but it's better to persist the script for debugging purposes
     scp -oStrictHostKeyChecking=no "$RUN_SCRIPT" "$SSH_USER@$SERVER_IP:/tmp/$BG_TASK_NAME.sh"
     ssh -oStrictHostKeyChecking=no "$SSH_USER@$SERVER_IP" "screen -X -S $BG_TASK_NAME quit || true" # Kill existing screen session
-    ssh -oStrictHostKeyChecking=no "$SSH_USER@$SERVER_IP" "screen -dmS $BG_TASK_NAME bash -c 'eval $ENV_CONTEXT; bash -x /tmp/$BG_TASK_NAME.sh'"
+
+    ssh -oStrictHostKeyChecking=no "$SSH_USER@$SERVER_IP" "screen -dmS $BG_TASK_NAME"
+    ssh -oStrictHostKeyChecking=no "$SSH_USER@$SERVER_IP" "screen -S $BG_TASK_NAME -X stuff '$ENV_CONTEXT'"
+    ssh -oStrictHostKeyChecking=no "$SSH_USER@$SERVER_IP" "screen -S $BG_TASK_NAME -X stuff '$RUN_SCRIPT'"
 fi


### PR DESCRIPTION
This hides ENV vars from being exposed as part of process name. 