### PR TITLE
feat: Skip consistency check for node if unavailable

### DIFF
--- a/tools/check-consistency.py
+++ b/tools/check-consistency.py
@@ -82,6 +82,10 @@ while True:
         )
 
         if response.status_code != 200:
+            if response.text == "Service Unavailable":
+                print(f"{uri} seems unavailable, skipping consistency check for this node")
+                continue
+
             print(f"Failed to fetch points from {uri}")
             print("Error response:", response.text)
             is_data_consistent = False


### PR DESCRIPTION
If node returns `Service Unavailable` means it's probably recovering. 

In such a case, it's better to skip consistency check for the node so it doesn't create false alarms for us.