### PR TITLE
feat: Monitor shards and shard transfers

### DIFF
--- a/tools/local/collect-node-metrics.sh
+++ b/tools/local/collect-node-metrics.sh
@@ -165,7 +165,7 @@ docker run --rm jbergknoff/postgresql-client "postgresql://qdrant:${POSTGRES_PAS
 # create table chaos_testing_shards (
 #   id SERIAL PRIMARY key,
 #   url VARCHAR(255),
-#   peer_id INT,
+#   peer_id bigint,
 #   shard_id INT,
 #   points_count INT,
 #   state VARCHAR(255),
@@ -182,7 +182,7 @@ fi
 # create table chaos_testing_transfers (
 #   id SERIAL PRIMARY key,
 #   url VARCHAR(255),
-#   peer_id INT,
+#   peer_id bigint,
 #   shard_id INT,
 #   from_peer INT,
 #   to_peer INT,


### PR DESCRIPTION
Introduce 2 new tables:
- `chaos_testing_shards`
- `chaos_testing_transfers`

Will also run:
- `CREATE INDEX idx_shards_timestamp ON chaos_testing_shards(measure_timestamp);`
- `CREATE INDEX idx_transfers_timestamp ON chaos_testing_transfers(measure_timestamp);`