### PR TITLE
feat: Store empty payload point ids in DB instead of using logs

### DIFF
--- a/tools/check-empty-payload.py
+++ b/tools/check-empty-payload.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python3
+
+# Not in use
 import os
 import requests
 

--- a/tools/local/collect-node-metrics.sh
+++ b/tools/local/collect-node-metrics.sh
@@ -90,20 +90,6 @@ function insert_to_chaos_testing_transfer_table {
     CHAOS_TESTING_TRANSFER_VALUES+=" ('$uri', $peer_id, $shard_id, $from_peer, $to_peer, '$method', '$comment', $progress_transfer, $total_to_transfer, '$measure_timestamp')"
 }
 
-# function to insert to CHAOS_TESTING_VALUES:
-function insert_to_chaos_testing_missing_payload_points_table {
-    local uri=$1
-    local missing_payload_point_ids=$2
-    local measure_timestamp=$3
-
-    if [ -n "$CHAOS_TESTING_MISSING_PAYLOAD_POINT_VALUES" ]; then
-        # If there are already values, add a comma
-        CHAOS_TESTING_MISSING_PAYLOAD_POINT_VALUES+=" ,"
-    fi
-
-    CHAOS_TESTING_MISSING_PAYLOAD_POINT_VALUES+=" ('$uri', '$missing_payload_point_ids' '$measure_timestamp')"
-}
-
 
 for uri in "${QDRANT_URIS[@]}"; do
     echo "level=INFO msg=\"Checking node\" uri=$uri"

--- a/tools/local/collect-node-metrics.sh
+++ b/tools/local/collect-node-metrics.sh
@@ -220,6 +220,7 @@ done
 #   commit CHAR(40),
 #   num_vectors INT,
 #   num_snapshots INT,
+#   missing_payload_point_ids JSONB,
 #   measure_timestamp TIMESTAMP
 # );
 

--- a/tools/local/run-collect-stats.sh
+++ b/tools/local/run-collect-stats.sh
@@ -41,7 +41,7 @@ while true; do
     export QDRANT_HOSTS_STR
 
     tools/local/check-cluster-health.sh
-    python3 tools/check-empty-payload.py
+    # python3 tools/check-empty-payload.py
     tools/local/collect-node-metrics.sh
 
     echo "level=INFO msg=\"Sleeping for 1m\""


### PR DESCRIPTION
Relying on logs is hard because LogQL is harder to use for graphs and less documented than I initially anticipated. I had to use hacks like `max_over_time` to make it work. 