### PR TITLE
Avoid false too many peers alert

### DIFF
--- a/tools/check-consistency.py
+++ b/tools/check-consistency.py
@@ -95,11 +95,14 @@ while True:
         exit(1)
     result = cluster_response.json()['result']
     num_peers = len(result["peers"])
+    pending_operations = result["raft_info"]["pending_operations"]
     peer_id = result['peer_id']
-    if num_peers < 5:
-        print(f'level=INFO msg="Fetched cluster peers" peer_id={peer_id} num_peers={num_peers}')
-    else:
+
+    if num_peers >= 5 and pending_operations == 0:
         print(f'level=CRITICAL msg="Fetched cluster peers. Found too many peers" num_peers={num_peers} peer_id={peer_id} response={result}')
+    else:
+        print(f'level=INFO msg="Fetched cluster peers" peer_id={peer_id} num_peers={num_peers}')
+
 
     QDRANT_URIS = [
         f"https://node-{idx}-{QDRANT_CLUSTER_URL}:6333" for idx in range(num_peers)

--- a/tools/local/collect-node-metrics.sh
+++ b/tools/local/collect-node-metrics.sh
@@ -121,8 +121,9 @@ for uri in "${QDRANT_URIS[@]}"; do
     consensus_status=$(echo "$cluster_response" | jq -rc '.result.consensus_thread_status.consensus_thread_status')
     peer_id=$(echo "$cluster_response" | jq '.result.peer_id')
     peer_count=$(echo "$cluster_response" | jq '.result.peers | length')
+    pending_operations=$(echo "$cluster_response" | jq '.result.raft_info.pending_operations')
     echo "level=INFO msg=\"Checked cluster\" consensus_status=$consensus_status peer_id=$peer_id uri=\"$uri\" cluster_response=\"$cluster_response\""
-    if [ "$peer_count" -gt 4 ]; then
+    if [ "$peer_count" -gt 4 ] && [ "$pending_operations" -eq 0 ]; then
         echo "level=CRITICAL msg=\"Cluster has too many peers\" consensus_status=$consensus_status peer_count=$peer_count peer_id=$peer_id uri=\"$uri\" cluster_response=\"$cluster_response\""
     fi
     if [ "$consensus_status" != "working" ]; then


### PR DESCRIPTION
Sometimes nodes are just catching up. So we see old peers in the cluster.

This should avoid `Too many peers` CRITICAL level log