### PR TITLE
Run ci workflows even on failure of previous jobs

### DIFF
--- a/.github/workflows/collect-stats.yaml
+++ b/.github/workflows/collect-stats.yaml
@@ -39,7 +39,7 @@ jobs:
         run: exit 1
 
   collect-stats-debug-cluster:
-    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' }}
+    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: collect-stats
     runs-on: ubuntu-latest
     steps:
@@ -70,8 +70,8 @@ jobs:
         if: steps.cluster_checks.outputs.failed == 'true'
         run: exit 1
 
-  collect-stats-3-cluster:
-    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' }}
+  collect-stats-three-cluster:
+    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: collect-stats-debug-cluster
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-snapshots.yaml
+++ b/.github/workflows/run-snapshots.yaml
@@ -31,7 +31,7 @@ jobs:
         run: exit 1
 
   run-snapshots-debug-cluster:
-    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'disable-snapshots' }}
+    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'disable-snapshots' && ! cancelled() }}
     needs: run-snapshots
     runs-on: ubuntu-latest
     steps:
@@ -56,7 +56,7 @@ jobs:
         run: exit 1
 
   run-snapshots-3-cluster:
-    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'disable-snapshots' }}
+    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'disable-snapshots' && ! cancelled() }}
     needs: run-snapshots-debug-cluster
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-bfb-search.yaml
+++ b/.github/workflows/update-bfb-search.yaml
@@ -48,7 +48,7 @@ jobs:
           export QC_NAME="qdrant-$(echo $QDRANT_CLUSTER_URL | sed -E 's~([^.]+)\..*~\1~')"
           bash -x tools/run-bfb-search.sh
 
-  update-bfb-search-3-cluster:
+  update-bfb-search-three-cluster:
     if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: update-bfb-search-debug-cluster
     runs-on: ubuntu-latest

--- a/.github/workflows/update-bfb-search.yaml
+++ b/.github/workflows/update-bfb-search.yaml
@@ -28,7 +28,7 @@ jobs:
           bash -x tools/run-bfb-search.sh
 
   update-bfb-search-debug-cluster:
-    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' }}
+    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: update-bfb-search
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +49,7 @@ jobs:
           bash -x tools/run-bfb-search.sh
 
   update-bfb-search-3-cluster:
-    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' }}
+    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: update-bfb-search-debug-cluster
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-bfb-upload.yaml
+++ b/.github/workflows/update-bfb-upload.yaml
@@ -28,7 +28,7 @@ jobs:
           bash -x tools/run-bfb-upload.sh
 
   update-bfb-upload-debug-cluster:
-    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' }}
+    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: update-bfb-upload
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +49,7 @@ jobs:
           bash -x tools/run-bfb-upload.sh
 
   update-bfb-upload-3-cluster:
-    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' }}
+    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: update-bfb-upload-debug-cluster
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-bfb-upload.yaml
+++ b/.github/workflows/update-bfb-upload.yaml
@@ -48,7 +48,7 @@ jobs:
           export QC_NAME="qdrant-$(echo $QDRANT_CLUSTER_URL | sed -E 's~([^.]+)\..*~\1~')"
           bash -x tools/run-bfb-upload.sh
 
-  update-bfb-upload-3-cluster:
+  update-bfb-upload-three-cluster:
     if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: update-bfb-upload-debug-cluster
     runs-on: ubuntu-latest

--- a/.github/workflows/update-collect-stats.yaml
+++ b/.github/workflows/update-collect-stats.yaml
@@ -66,7 +66,7 @@ jobs:
           export BG_TASK_NAME=${{ inputs.bg_task_name }}
           bash -x tools/run-collect-stats.sh
 
-  update-collect-stats-3-cluster:
+  update-collect-stats-three-cluster:
     if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: update-collect-stats-debug-cluster
     runs-on: ubuntu-latest

--- a/.github/workflows/update-collect-stats.yaml
+++ b/.github/workflows/update-collect-stats.yaml
@@ -42,7 +42,7 @@ jobs:
           bash -x tools/run-collect-stats.sh
 
   update-collect-stats-debug-cluster:
-    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' }}
+    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: update-collect-stats
     runs-on: ubuntu-latest
     steps:
@@ -67,7 +67,7 @@ jobs:
           bash -x tools/run-collect-stats.sh
 
   update-collect-stats-3-cluster:
-    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' }}
+    if: ${{ vars.ENABLE_DEBUG_CLUSTER == 'true' && ! cancelled() }}
     needs: update-collect-stats-debug-cluster
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Example run: https://github.com/qdrant/haloperidol/actions/runs/11680252429