### PR TITLE
Retry inconsistency checks after a HTTP 500

### DIFF
--- a/tools/check-consistency-improved.py
+++ b/tools/check-consistency-improved.py
@@ -116,7 +116,8 @@ while retries > 0:
         print(
             f'level=ERROR msg="Failed to retrieve inconsistent points" error="{str(e)}"'
         )
-        exit(1)
+        time.sleep(5)
+        continue
 
     if not inconsistent_points:
         print(


### PR DESCRIPTION
Still retry if we receive an HTTP 500 while checking point consistency.

I'm not entirely sure this is implemented correctly, so please review with care.