### PR TITLE
Suppress known errors in consistency check and refactor script

### DIFF
--- a/tools/check-consistency-improved.py
+++ b/tools/check-consistency-improved.py
@@ -1,13 +1,14 @@
 #!/bin/python3
-import requests
 import time
-
 import os
 import builtins
 
+from typing import Set
 from qdrant_client import QdrantClient, models
 
 pid = os.getpid()
+
+PointId = int
 
 def print(*args, **kwargs):
     new_args = args + (f"pid={pid}",)
@@ -34,119 +35,87 @@ QDRANT_API_KEY = os.getenv("QDRANT_API_KEY", "")
 QDRANT_CLUSTER_URL = os.getenv("QDRANT_CLUSTER_URL", "")
 CONSISTENCY_ATTEMPTS_TOTAL = 10
 COLLECTION_NAME = "benchmark"
-
-
-def check_response_from_cluster():
-    try:
-        cluster_response = requests.get(
-            f"https://{QDRANT_CLUSTER_URL}:6333/cluster",
-            headers={"api-key": QDRANT_API_KEY},
-            timeout=10,
-        )
-    except requests.exceptions.Timeout:
-        print(
-            f'level=ERROR msg="Request timed out after 10s" uri="{QDRANT_CLUSTER_URL}" api="/cluster"'
-        )
-        exit(1)
-
-    if cluster_response.status_code != 200:
-        print(
-            f'level=ERROR msg="Got error in response" status_code={cluster_response.status_code} api="/cluster" response="{cluster_response.text}"'
-        )
-        exit(1)
-
-
-def get_inconsistent_points_ids_from_all():
-    points, _nxt = qdrant_client.scroll(
-        COLLECTION_NAME,
-        limit=num_points_to_check,
-        with_payload=['timestamp'],
-        with_vectors=False,
-        consistency=models.ReadConsistencyType.ALL
-    )
-
-    found_points = set([int(point.id) for point in points])
-    missing_points = initial_point_ids_set - found_points
-
-    return list(missing_points)
-
-
-def get_inconsistent_points_ids_from_list(point_ids):
-    points = qdrant_client.retrieve(
-        COLLECTION_NAME,
-        point_ids,
-        with_payload=['timestamp'],
-        with_vectors=False,
-        consistency=models.ReadConsistencyType.ALL
-    )
-
-    expected_points = set(point_ids)
-    found_points = set([int(point.id) for point in points])
-    missing_points = list(expected_points - found_points)
-    return missing_points
-
+QDRANT_REQUEST_TIMEOUT = 30
 
 num_points_to_check = 200000
-initial_point_ids = list(range(num_points_to_check))
-initial_point_ids_set = set(range(num_points_to_check))
-point_ids_for_node = list(range(num_points_to_check))
-is_data_consistent = False
+initial_point_ids = set(range(num_points_to_check))
+
+qdrant_client = QdrantClient(
+    url=QDRANT_CLUSTER_URL, api_key=QDRANT_API_KEY, timeout=100
+)
+IGNORED_ERRORS = ["does not have enough active replicas"]
+
+class IgnoredError(Exception):
+    pass
+
+def get_inconsistent_points_ids(point_ids: Set[PointId]) -> Set[PointId]:
+    """Returns (bool, set) where bool represents whether it passed successfully"""
+    try:
+        if len(point_ids) == num_points_to_check:
+            # It's faster to use scroll
+            points_ids = initial_point_ids
+            points, _nxt = qdrant_client.scroll(
+                COLLECTION_NAME,
+                limit=num_points_to_check,
+                with_payload=["timestamp"],
+                with_vectors=False,
+                consistency=models.ReadConsistencyType.ALL,
+            )
+        else:
+            points = qdrant_client.retrieve(
+                COLLECTION_NAME,
+                point_ids,
+                with_payload=["timestamp"],
+                with_vectors=False,
+                consistency=models.ReadConsistencyType.ALL,
+            )
+        found_points = set([int(point.id) for point in points])
+        missing_points = points_ids - found_points
+
+        return missing_points
+    except Exception as e:
+        e_str = str(e)
+
+        if any(ignored_err in e_str for ignored_err in IGNORED_ERRORS):
+            raise IgnoredError(e_str)
+
+        raise e
+
+# Assume all points are inconsistent
+inconsistent_points = initial_point_ids
 consistency_attempts_remaining = CONSISTENCY_ATTEMPTS_TOTAL
-node_to_points_map = {}
-consistent_points = {}
-qdrant_client = QdrantClient(url=QDRANT_CLUSTER_URL, api_key=QDRANT_API_KEY, timeout=100)
 
-
-try:
-    inconsistent_points = get_inconsistent_points_ids_from_all()
-except Exception as e:
-    print(
-        f'level=ERROR msg="Failed to retrieve all points" error="{str(e)}"'
-    )
-    exit(1)
-
-retries = CONSISTENCY_ATTEMPTS_TOTAL
-while retries > 0:
-    retries -= 1
+while True:
     consistency_attempts_remaining -= 1
 
     try:
-        inconsistent_points = get_inconsistent_points_ids_from_list(inconsistent_points)
+        inconsistent_points = get_inconsistent_points_ids(inconsistent_points)
+    except IgnoredError as e:
+        e_str = str(e).replace("\n", " ")
+        print(f'level=WARN msg="Failed to retrieve inconsistent points. But ignoring error and passing check" error="{e_str}"')
+        exit(0)
     except Exception as e:
-        print(
-            f'level=ERROR msg="Failed to retrieve inconsistent points" error="{str(e)}"'
-        )
-        time.sleep(5)
-        continue
+        e_str = str(e).replace("\n", " ")
+        print(f'level=WARN msg="Failed to retrieve inconsistent points" error="{e_str}"')
 
-    if not inconsistent_points:
+    if len(inconsistent_points) == 0:
         print(
             f'level=INFO msg="Data consistency check succeeded" attempts={CONSISTENCY_ATTEMPTS_TOTAL - consistency_attempts_remaining} inconsistent_count=0 inconsistent_points="[]"'
         )
         exit(0)
     else:
+        sample_inconsistent_points = sorted(list(inconsistent_points))[:20]
+
         if consistency_attempts_remaining == 0:
             print(
-                f'level=ERROR msg="Data consistency check failed" attempts={CONSISTENCY_ATTEMPTS_TOTAL - consistency_attempts_remaining} inconsistent_count={len(inconsistent_points)} inconsistent_points="{sorted(inconsistent_points[:20])}"'
+                f'level=ERROR msg="Data consistency check failed" attempts={CONSISTENCY_ATTEMPTS_TOTAL - consistency_attempts_remaining} inconsistent_count={len(inconsistent_points)} sample_inconsistent_points="{sample_inconsistent_points}"'
             )
             exit(1)
         else:
             print(
-                f'level=WARN msg="Nodes might be inconsistent. Will retry" inconsistent_count={len(inconsistent_points)} inconsistent_points="{sorted(inconsistent_points[:20])}"'
+                f'level=WARN msg="Nodes might be inconsistent. Will retry" inconsistent_count={len(inconsistent_points)} sample_inconsistent_points="{sample_inconsistent_points}"'
             )
             print(
                 f'level=WARN msg="Retrying data consistency check, inconsistent points only" inconsistent_count={len(inconsistent_points)} attempts={CONSISTENCY_ATTEMPTS_TOTAL - consistency_attempts_remaining} remaining_attempts={consistency_attempts_remaining}'
             )
             time.sleep(5)
-
-
-if inconsistent_points:
-    print(
-        f'level=ERROR msg="Data consistency check failed" attempts={CONSISTENCY_ATTEMPTS_TOTAL - consistency_attempts_remaining} inconsistent_count={len(inconsistent_points)} inconsistent_points="{sorted(inconsistent_points[:20])}"'
-    )
-    exit(1)
-else:
-    print(
-        f'level=INFO msg="Data consistency check succeeded" attempts={CONSISTENCY_ATTEMPTS_TOTAL - consistency_attempts_remaining} inconsistent_count=0 inconsistent_points="[]"'
-    )
-    exit(0)


### PR DESCRIPTION
chaos testing graphs become too noisy because we often see errors like this:
```json
{"status":{"error":"Service internal error: The replica set for shard 1 on peer 6414733040631660 does not have enough active replicas"}
```

It's better to ignore known errors so we don't start ignoring actual detected issues .